### PR TITLE
- Bump jakarta.servlet-api from 5.0.0 to 6.0.0

### DIFF
--- a/resteasy-spring-mvc/pom.xml
+++ b/resteasy-spring-mvc/pom.xml
@@ -40,7 +40,7 @@
 
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.spring>3.0.2.Final</version.org.jboss.resteasy.spring>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>27.0.0.Beta1</version.org.wildfly>

--- a/resteasy-spring-undertow/pom.xml
+++ b/resteasy-spring-undertow/pom.xml
@@ -38,9 +38,10 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
 
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.spring>3.0.2.Final</version.org.jboss.resteasy.spring>
         <version.org.junit>5.9.3</version.org.junit>
+        <version.jakarta.servlet-api>6.0.0</version.jakarta.servlet-api>
 
         <!-- Plugin Versions -->
         <version.jandex.maven.plugin>1.2.3</version.jandex.maven.plugin>
@@ -76,7 +77,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>${version.jakarta.servlet-api}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Bump resteasy-bom from 6.2.3.Final to 6.2.4.Final